### PR TITLE
drop Scala 2.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17]
-        scala: [2.11.x, 2.12.x, 2.13.x]
+        scala: [2.12.x, 2.13.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.lightbend"
 version := "0.0.1"
 name := "cloc-plugin"
 scalaVersion := crossScalaVersions.value.head
-crossScalaVersions := Seq("2.11.12", "2.12.17", "2.13.11")
+crossScalaVersions := Seq("2.12.17", "2.13.11")
 crossVersion := CrossVersion.patch
 libraryDependencies +=
   "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"


### PR DESCRIPTION
it will remain available in the git history, since this is primarily a code example anyway

(its other purpose is for use in the Scala 2 community build, but we dropped 2.11 there a while back)
